### PR TITLE
Fix for non-ssl version

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,7 +170,7 @@ fn unescape_content(response: ApiResponse) -> Joke {
 
 #[cfg(not(feature="ssl"))]
 fn create_client() -> hyper::Client {
-    Client::new()
+    hyper::Client::new()
 }
 
 #[cfg(feature="ssl")]


### PR DESCRIPTION
The last patch introduced a compilation error for the non-ssl edition. I was not aware that cargo doesn't build all code paths when it does a check on this kind of crap. oO

This PR fixes the error.